### PR TITLE
Wait for cluster to be ready before flipping the flags

### DIFF
--- a/enable_git_proxy_jupyter_v0.1.0.ipynb
+++ b/enable_git_proxy_jupyter_v0.1.0.ipynb
@@ -4,10 +4,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "09428fe1-c76a-4d03-8deb-acbd94050594",
      "showTitle": false,
@@ -22,10 +19,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "d139a95c-8953-4a5a-8373-38e0d52b084a",
      "showTitle": false,
@@ -50,10 +44,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "4e1623df-034f-4853-b544-cf70a491702d",
      "showTitle": false,
@@ -68,10 +59,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "48beb9ca-d6a5-4ebd-9370-17035d3af9de",
      "showTitle": false,
@@ -118,6 +106,7 @@
     "CLUSTERS_LIST_ENDPOINT = \"/api/2.0/clusters/list\"\n",
     "CLUSTERS_CREATE_ENDPOINT = \"/api/2.0/clusters/create\"\n",
     "CLUSTERS_LIST_NODE_TYPES_ENDPOINT = \"/api/2.0/clusters/list-node-types\"\n",
+    "CLUSTERS_GET_ENDPOINT = \"/api/2.0/clusters/get\"\n",
     "\n",
     "# Permissions\n",
     "UPDATE_PERMISSIONS_ENDPOINT = \"/api/2.0/permissions/clusters\"\n",
@@ -130,10 +119,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "2a33316f-5212-4561-b3f0-d971d3fdc619",
      "showTitle": false,
@@ -243,10 +229,59 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "e588938a-e523-46cf-99de-a9932c6d7174",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "source": [
+    "# Wait for the cluster to be ready\n",
+    "\n",
+    "Before we can send traffic to it, we should wait for the cluster to be up and ready to serve traffic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "631cebda-ffc1-4f89-8e20-82466b780bc6",
+     "showTitle": false,
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import time \n",
+    "\n",
+    "sleep_time_s = 10\n",
+    "\n",
+    "state = None\n",
+    "while True:\n",
+    "    time.sleep(10)\n",
+    "    clusters_get_response = requests.get(\n",
+    "        url=databricks_instance + CLUSTERS_GET_ENDPOINT,\n",
+    "        headers=headers,\n",
+    "        params={\"cluster_id\": cluster_id }\n",
+    "    ).json()\n",
+    "    state = clusters_get_response.get(\"state\", None)\n",
+    "    if state == 'RUNNING':\n",
+    "        print(\"Cluster is ready!\")\n",
+    "        break\n",
+    "    else:\n",
+    "        print(\"Cluster is in state %s, waiting for %s seconds and trying again\" % (sleep_time_s, state)\n",
+    "        time.sleep(sleep_time_s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "cec1268f-5134-4bf5-9fc0-23140492558b",
      "showTitle": false,
@@ -296,10 +331,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "814082f8-5526-4835-b864-0a426c1b6926",
      "showTitle": false,
@@ -347,10 +379,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "120f1fcc-abc2-49d8-acd0-6eaaca0f9e9c",
      "showTitle": false,
@@ -365,10 +394,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "735e9217-6cd7-41b2-9d7a-0caf3a19d795",
      "showTitle": false,
@@ -384,10 +410,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "9e944a34-e628-46be-b110-ba474ee48921",
      "showTitle": false,
@@ -419,7 +442,7 @@
     "pythonIndentUnit": 4,
     "widgetLayout": []
    },
-   "notebookName": "enable_managed_git_proxy_jupyter",
+   "notebookName": "enable_git_proxy_jupyter_v0.1.0",
    "widgets": {}
   }
  },


### PR DESCRIPTION
After creating the cluster, we wait for the cluster to be ready before turning on the flag to avoid git operations failing while we wait for the cluster to be ready.

This is especially useful when upgrading from a previous version to avoid downtime.